### PR TITLE
typo in option parsing for audio visualizations

### DIFF
--- a/modules/visualization/visual/visual.c
+++ b/modules/visualization/visual/visual.c
@@ -201,7 +201,7 @@ static int Open( vlc_object_t *p_this )
         return VLC_EGENERIC;
 
     int width = var_InheritInteger( p_filter , "effect-width");
-    int height = var_InheritInteger( p_filter , "effect-width");
+    int height = var_InheritInteger( p_filter , "effect-height");
     /* No resolution under 400x532 and no odd dimension */
     if( width < 532 )
         width  = 532;


### PR DESCRIPTION
`height` was incorrectly parsed from `effect-width`

This was a regression introduced
in 1f02e8c05849229573393e14268ed7dddc5d174b
from b2262bc3649b61d93df0d756017dafb9d2ad5822